### PR TITLE
Add authentication service and hook

### DIFF
--- a/src/hooks/use-auth.ts
+++ b/src/hooks/use-auth.ts
@@ -1,0 +1,60 @@
+import { useState, useCallback } from "react";
+import {
+  login as loginApi,
+  signup as signupApi,
+  logout as logoutApi,
+  getShortToken,
+  getBearerToken,
+} from "@/services/auth";
+
+interface LoginArgs {
+  email: string;
+  password: string;
+}
+
+interface SignupArgs {
+  email: string;
+  password: string;
+  email_code?: string;
+  invite_code?: string;
+  recaptcha_data?: string;
+}
+
+export function useAuth() {
+  const [token, setToken] = useState<string | null>(() => getShortToken());
+  const [bearer, setBearer] = useState<string | null>(() => getBearerToken());
+  const [isAdmin, setIsAdmin] = useState(false);
+
+  const login = useCallback(async (args: LoginArgs) => {
+    const data = await loginApi(args);
+    setToken(data.token);
+    setBearer(data.auth_data);
+    setIsAdmin(!!data.is_admin);
+    return data;
+  }, []);
+
+  const signup = useCallback(async (args: SignupArgs) => {
+    const data = await signupApi(args);
+    setToken(data.token);
+    setBearer(data.auth_data);
+    setIsAdmin(!!data.is_admin);
+    return data;
+  }, []);
+
+  const logout = useCallback(() => {
+    logoutApi();
+    setToken(null);
+    setBearer(null);
+    setIsAdmin(false);
+  }, []);
+
+  return {
+    token,
+    bearerToken: bearer,
+    isLoggedIn: !!token,
+    isAdmin,
+    login,
+    signup,
+    logout,
+  };
+}

--- a/src/services/auth.ts
+++ b/src/services/auth.ts
@@ -1,0 +1,106 @@
+import axios, { AxiosInstance } from "axios";
+
+interface ApiResponse<T> {
+  status: string;
+  message: string;
+  data: T;
+  error?: any;
+}
+
+interface LoginResponseData {
+  token: string;
+  auth_data: string;
+  is_admin: number;
+}
+
+interface SignupPayload {
+  email: string;
+  password: string;
+  email_code?: string;
+  invite_code?: string;
+  recaptcha_data?: string;
+}
+
+interface LoginPayload {
+  email: string;
+  password: string;
+}
+
+const TOKEN_KEY = "auth_token";
+const BEARER_KEY = "auth_bearer";
+
+let apiBaseUrlPromise: Promise<string> | null = null;
+async function getApiBaseUrl(): Promise<string> {
+  if (!apiBaseUrlPromise) {
+    apiBaseUrlPromise = axios
+      .get<ApiResponse<any>>("/api-proxy/globalize/v1/guest/comm/config")
+      .then((r) => r.data.app_url || r.data.data?.app_url || "");
+  }
+  return apiBaseUrlPromise;
+}
+
+let instancePromise: Promise<AxiosInstance> | null = null;
+async function getAxios(): Promise<AxiosInstance> {
+  if (!instancePromise) {
+    instancePromise = (async () => {
+      const baseURL = await getApiBaseUrl();
+      const authHeader = getBearerToken();
+      const ins = axios.create({
+        baseURL,
+        headers: authHeader ? { Authorization: authHeader } : {},
+        timeout: 15000,
+      });
+      ins.interceptors.response.use((r) => r.data);
+      return ins;
+    })();
+  }
+  return instancePromise;
+}
+
+function saveTokens(token: string, bearer: string) {
+  localStorage.setItem(TOKEN_KEY, token);
+  localStorage.setItem(BEARER_KEY, bearer);
+  instancePromise = null;
+}
+
+export function getShortToken() {
+  return localStorage.getItem(TOKEN_KEY);
+}
+
+export function getBearerToken() {
+  return localStorage.getItem(BEARER_KEY);
+}
+
+export function clearTokens() {
+  localStorage.removeItem(TOKEN_KEY);
+  localStorage.removeItem(BEARER_KEY);
+  instancePromise = null;
+}
+
+export async function login(payload: LoginPayload): Promise<LoginResponseData> {
+  const ins = await getAxios();
+  const res = await ins.post<ApiResponse<LoginResponseData>>(
+    "/globalize/v1/passport/auth/login",
+    payload,
+  );
+  const data = res.data;
+  saveTokens(data.token, data.auth_data);
+  return data;
+}
+
+export async function signup(
+  payload: SignupPayload,
+): Promise<LoginResponseData> {
+  const ins = await getAxios();
+  const res = await ins.post<ApiResponse<LoginResponseData>>(
+    "/globalize/v1/passport/auth/register",
+    payload,
+  );
+  const data = res.data;
+  saveTokens(data.token, data.auth_data);
+  return data;
+}
+
+export async function logout() {
+  clearTokens();
+}


### PR DESCRIPTION
## Summary
- add authentication service with login, signup and logout helpers
- store tokens in localStorage and manage axios instance
- expose `useAuth` hook to access auth state in React components

## Testing
- `pnpm format`
- `pnpm format:check`


------
https://chatgpt.com/codex/tasks/task_e_684e8afa04ec8328a2e66ac76f690fd7