### PR TITLE
Implement OSS domain service

### DIFF
--- a/src/services/auth.ts
+++ b/src/services/auth.ts
@@ -1,4 +1,5 @@
 import axios, { AxiosInstance } from "axios";
+import { getOssBaseUrl } from "./domain_service";
 
 interface ApiResponse<T> {
   status: string;
@@ -29,21 +30,11 @@ interface LoginPayload {
 const TOKEN_KEY = "auth_token";
 const BEARER_KEY = "auth_bearer";
 
-let apiBaseUrlPromise: Promise<string> | null = null;
-async function getApiBaseUrl(): Promise<string> {
-  if (!apiBaseUrlPromise) {
-    apiBaseUrlPromise = axios
-      .get<ApiResponse<any>>("/api-proxy/globalize/v1/guest/comm/config")
-      .then((r) => (r.data as any).app_url || r.data.data?.app_url || "");
-  }
-  return apiBaseUrlPromise;
-}
-
 let instancePromise: Promise<AxiosInstance> | null = null;
 async function getAxios(): Promise<AxiosInstance> {
   if (!instancePromise) {
     instancePromise = (async () => {
-      const baseURL = await getApiBaseUrl();
+      const baseURL = await getOssBaseUrl();
       const authHeader = getBearerToken();
       const ins = axios.create({
         baseURL,

--- a/src/services/domain_service.ts
+++ b/src/services/domain_service.ts
@@ -1,0 +1,43 @@
+export const ossDomain = "https://oss01.980410.xyz/pandaoss.conf.json";
+
+import axios from "axios";
+
+const CACHE_KEY = "oss_base_url";
+
+export interface OssConfigItem {
+  name: string;
+  url: string;
+}
+
+export async function fetchOssConfig(): Promise<OssConfigItem[]> {
+  try {
+    const { data } = await axios.get<OssConfigItem[]>(ossDomain, {
+      timeout: 10000,
+    });
+    if (!Array.isArray(data)) {
+      throw new Error("Invalid oss config format");
+    }
+    return data;
+  } catch (err: any) {
+    console.error("Failed to fetch oss config", err);
+    throw new Error(err?.message || "Failed to fetch oss config");
+  }
+}
+
+let baseUrlPromise: Promise<string> | null = null;
+export async function getOssBaseUrl(): Promise<string> {
+  if (!baseUrlPromise) {
+    baseUrlPromise = (async () => {
+      const cached = localStorage.getItem(CACHE_KEY);
+      if (cached) return cached;
+      const configs = await fetchOssConfig();
+      if (!configs.length) {
+        throw new Error("OSS config is empty");
+      }
+      const { url } = configs[Math.floor(Math.random() * configs.length)];
+      localStorage.setItem(CACHE_KEY, url);
+      return url;
+    })();
+  }
+  return baseUrlPromise;
+}


### PR DESCRIPTION
## Summary
- add `domain_service.ts` with functions for fetching OSS config and caching base URL
- update `auth.ts` to use the new OSS base URL for API calls

## Testing
- `pnpm format:check`
- `pnpm format`


------
https://chatgpt.com/codex/tasks/task_e_684ea386694c83289a64ac32f1e3e7b5