### PR TITLE
Use js-cookie for authentication tokens

### DIFF
--- a/package.json
+++ b/package.json
@@ -57,6 +57,7 @@
     "glob": "^11.0.2",
     "i18next": "^25.2.1",
     "js-base64": "^3.7.7",
+    "js-cookie": "^3.0.5",
     "js-yaml": "^4.1.0",
     "lodash-es": "^4.17.21",
     "monaco-editor": "^0.52.2",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -104,6 +104,9 @@ importers:
       js-base64:
         specifier: ^3.7.7
         version: 3.7.7
+      js-cookie:
+        specifier: ^3.0.5
+        version: 3.0.5
       js-yaml:
         specifier: ^4.1.0
         version: 4.1.0

--- a/src/services/auth.ts
+++ b/src/services/auth.ts
@@ -1,4 +1,5 @@
 import axios, { AxiosInstance } from "axios";
+import Cookies from "js-cookie";
 import { getOssBaseUrl } from "./domain_service";
 
 interface ApiResponse<T> {
@@ -49,22 +50,22 @@ async function getAxios(): Promise<AxiosInstance> {
 }
 
 function saveTokens(token: string, bearer: string) {
-  localStorage.setItem(TOKEN_KEY, token);
-  localStorage.setItem(BEARER_KEY, bearer);
+  Cookies.set(TOKEN_KEY, token, { expires: 30 });
+  Cookies.set(BEARER_KEY, bearer, { expires: 30 });
   instancePromise = null;
 }
 
-export function getShortToken() {
-  return localStorage.getItem(TOKEN_KEY);
+export function getShortToken(): string | null {
+  return Cookies.get(TOKEN_KEY) ?? null;
 }
 
-export function getBearerToken() {
-  return localStorage.getItem(BEARER_KEY);
+export function getBearerToken(): string | null {
+  return Cookies.get(BEARER_KEY) ?? null;
 }
 
 export function clearTokens() {
-  localStorage.removeItem(TOKEN_KEY);
-  localStorage.removeItem(BEARER_KEY);
+  Cookies.remove(TOKEN_KEY);
+  Cookies.remove(BEARER_KEY);
   instancePromise = null;
 }
 


### PR DESCRIPTION
## Summary
- store auth tokens in browser cookies instead of localStorage
- install js-cookie runtime dependency

## Testing
- `pnpm format`
- `pnpm format:check`
- `pnpm run check` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_684ec90f33f8832896ac09f37e5686a4