### PR TITLE
Add auto-import of subscription profiles

### DIFF
--- a/src/hooks/use-user.ts
+++ b/src/hooks/use-user.ts
@@ -78,8 +78,8 @@ export const generateInviteCode = async () => {
 
 export const importSubscribeProfile = async () => {
   try {
-    const { data } = await fetchUserSubscribe();
-    const url = data.subscribe_url;
+    const res = await fetchUserSubscribe();
+    const url = res.data.subscribe_url;
     await importProfile(url);
     mutate("getProfiles");
     showNotice("success", i18next.t("Import Subscription Successful"));

--- a/src/hooks/use-user.ts
+++ b/src/hooks/use-user.ts
@@ -1,4 +1,4 @@
-import useSWR from "swr";
+import useSWR, { mutate } from "swr";
 import {
   fetchUserCommConfig,
   fetchUserInfo,
@@ -18,6 +18,9 @@ import {
   ChangePasswordRequest,
   TransferRequest,
 } from "@/services/user";
+import { importProfile } from "@/services/cmds";
+import { showNotice } from "@/services/noticeService";
+import i18next from "i18next";
 
 export const useUserInfo = () => {
   const { data, mutate } = useSWR("userInfo", fetchUserInfo);
@@ -71,6 +74,18 @@ export const sendTransferCommission = async (payload: TransferRequest) => {
 
 export const generateInviteCode = async () => {
   await createInviteCode();
+};
+
+export const importSubscribeProfile = async () => {
+  try {
+    const { data } = await fetchUserSubscribe();
+    const url = data.subscribe_url;
+    await importProfile(url);
+    mutate("getProfiles");
+    showNotice("success", i18next.t("Import Subscription Successful"));
+  } catch (err: any) {
+    showNotice("error", err?.message || err.toString());
+  }
 };
 
 export const useUser = () => {

--- a/src/locales/tt.json
+++ b/src/locales/tt.json
@@ -377,7 +377,7 @@
   "Clash Core Restarted": "Clash ядросы яңадан башланды",
   "GeoData Updated": "GeoData яңартылды",
   "Currently on the Latest Version": "Сездә иң соңгы версия урнаштырылган",
-  "Import subscription successful": "Подписка уңышлы импортланды",
+  "Import Subscription Successful": "Подписка уңышлы импортланды",
   "WebDAV Server URL": "WebDAV сервер URL-ы (http(s)://)",
   "Username": "Кулланучы исеме",
   "Password": "Пароль",

--- a/src/pages/login.tsx
+++ b/src/pages/login.tsx
@@ -5,6 +5,7 @@ import { useNavigate, Link as RouterLink } from "react-router-dom";
 import { BasePage } from "@/components/base";
 import { showNotice } from "@/services/noticeService";
 import { useAuth } from "@/hooks/use-auth";
+import { importSubscribeProfile } from "@/hooks/use-user";
 
 const LoginPage = () => {
   const { t } = useTranslation();
@@ -19,6 +20,7 @@ const LoginPage = () => {
     setLoading(true);
     try {
       await login({ email, password });
+      await importSubscribeProfile();
       showNotice("success", t("Login Successful"));
       navigate("/");
     } catch (err: any) {

--- a/src/pages/signup.tsx
+++ b/src/pages/signup.tsx
@@ -5,6 +5,7 @@ import { useNavigate, Link as RouterLink } from "react-router-dom";
 import { BasePage } from "@/components/base";
 import { showNotice } from "@/services/noticeService";
 import { useAuth } from "@/hooks/use-auth";
+import { importSubscribeProfile } from "@/hooks/use-user";
 
 const SignupPage = () => {
   const { t } = useTranslation();
@@ -19,6 +20,7 @@ const SignupPage = () => {
     setLoading(true);
     try {
       await signup({ email, password });
+      await importSubscribeProfile();
       showNotice("success", t("Signup Successful"));
       navigate("/");
     } catch (err: any) {

--- a/src/pages/user-info.tsx
+++ b/src/pages/user-info.tsx
@@ -15,7 +15,7 @@ const UserInfoPage = () => {
   const { t } = useTranslation();
   const { userInfo, mutateUserInfo } = useUserInfo();
   const { data: subResp } = useUserSubscribe();
-  const subscribe = subResp?.data.data;
+  const subscribe = subResp?.data;
 
   const [remindExpire, setRemindExpire] = useState<number>(0);
   const [remindTraffic, setRemindTraffic] = useState<number>(0);

--- a/src/services/user.ts
+++ b/src/services/user.ts
@@ -157,11 +157,14 @@ export const changePassword = async (payload: ChangePasswordRequest) => {
   );
 };
 
-export const fetchUserSubscribe = async () => {
+export const fetchUserSubscribe = async (): Promise<
+  ApiResponse<UserSubscribeData>
+> => {
   const ins = await getAuthAxios();
-  return ins.get<ApiResponse<UserSubscribeData>>(
+  const res = await ins.get<ApiResponse<UserSubscribeData>>(
     "/globalize/v1/user/getSubscribe",
   );
+  return res as unknown as ApiResponse<UserSubscribeData>;
 };
 
 export const fetchTelegramBotInfo = async () => {


### PR DESCRIPTION
## Summary
- import server subscription profiles upon login/signup
- add helper `importSubscribeProfile`
- update login and signup pages to trigger subscription import
- add missing translation string in `tt.json`

## Testing
- `pnpm format:check`
- `pnpm fmt` *(fails: `cargo-fmt` not installed)*
- `pnpm clippy` *(fails: `cargo-clippy` not installed)*
- `pnpm web:build` *(fails: type errors due to missing modules)*

------
https://chatgpt.com/codex/tasks/task_e_684ed243fe708328ac9d8a9ad441a53f