### PR TITLE
Add Codex build workflow

### DIFF
--- a/.github/workflows/build-codex.yml
+++ b/.github/workflows/build-codex.yml
@@ -1,0 +1,80 @@
+name: Codex Build
+
+on:
+  workflow_dispatch:
+
+jobs:
+  build:
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - os: windows-latest
+            target: x86_64-pc-windows-msvc
+          - os: macos-latest
+            target: aarch64-apple-darwin
+          - os: macos-latest
+            target: x86_64-apple-darwin
+          - os: ubuntu-22.04
+            target: x86_64-unknown-linux-gnu
+    runs-on: ${{ matrix.os }}
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Install Rust
+        uses: dtolnay/rust-toolchain@stable
+        with:
+          targets: ${{ matrix.target }}
+
+      - name: Add Rust target
+        run: rustup target add ${{ matrix.target }}
+
+      - name: Install Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: "20"
+
+      - uses: pnpm/action-setup@v4
+        name: Install pnpm
+        with:
+          run_install: false
+
+      - name: Install dependencies
+        run: pnpm i
+
+      - name: Prepare target
+        run: pnpm prepare ${{ matrix.target }}
+
+      - name: Build with Tauri
+        uses: tauri-apps/tauri-action@v0
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          tauriScript: pnpm
+          args: --target ${{ matrix.target }}
+
+      - name: Upload macOS Artifacts
+        if: matrix.os == 'macos-latest'
+        uses: actions/upload-artifact@v4
+        with:
+          name: ${{ matrix.target }}
+          path: src-tauri/target/${{ matrix.target }}/release/bundle/dmg/*.dmg
+          if-no-files-found: error
+
+      - name: Upload Windows Artifacts
+        if: matrix.os == 'windows-latest'
+        uses: actions/upload-artifact@v4
+        with:
+          name: ${{ matrix.target }}
+          path: src-tauri/target/${{ matrix.target }}/release/bundle/nsis/*.exe
+          if-no-files-found: error
+
+      - name: Upload Linux Artifacts
+        if: matrix.os == 'ubuntu-22.04'
+        uses: actions/upload-artifact@v4
+        with:
+          name: ${{ matrix.target }}
+          path: |
+            src-tauri/target/${{ matrix.target }}/release/bundle/deb/*.deb
+            src-tauri/target/${{ matrix.target }}/release/bundle/appimage/*.AppImage
+          if-no-files-found: error

--- a/README.md
+++ b/README.md
@@ -92,6 +92,12 @@ pnpm run check
 pnpm dev
 ```
 
+## build-all Workflow
+
+The repository provides a **build-all.yml** workflow that compiles packages for every platform.
+You can run it manually from the **Actions** tab by selecting **build-all** and clicking **Run workflow**.
+macOS artifacts produced by this workflow are unsigned and may require manual notarization before distribution.
+
 ## Contributions
 
 Issue and PR welcome!


### PR DESCRIPTION
## Summary
- add `build-codex.yml` for multi-platform tauri builds
- document how to trigger `build-all.yml` manually

## Testing
- `pnpm fmt`
- `pnpm format:check`


------
https://chatgpt.com/codex/tasks/task_e_684ee3a659bc832886d7a8a42ff98fa5