### PR TITLE
Rename application to Homiefroxy

### DIFF
--- a/scripts/portable-fixed-webview2.mjs
+++ b/scripts/portable-fixed-webview2.mjs
@@ -42,7 +42,7 @@ async function resolvePortable() {
 
   const zip = new AdmZip();
 
-  zip.addLocalFile(path.join(releaseDir, "Clash Verge.exe"));
+  zip.addLocalFile(path.join(releaseDir, "Homiefroxy.exe"));
   zip.addLocalFile(path.join(releaseDir, "verge-mihomo.exe"));
   zip.addLocalFile(path.join(releaseDir, "verge-mihomo-alpha.exe"));
   zip.addLocalFolder(path.join(releaseDir, "resources"), "resources");
@@ -59,7 +59,7 @@ async function resolvePortable() {
   const packageJson = require("../package.json");
   const { version } = packageJson;
 
-  const zipFile = `Clash.Verge_${version}_${arch}_fixed_webview2_portable.zip`;
+  const zipFile = `Homiefroxy_${version}_${arch}_fixed_webview2_portable.zip`;
   zip.writeZip(zipFile);
 
   console.log("[INFO]: create portable zip successfully");

--- a/scripts/portable.mjs
+++ b/scripts/portable.mjs
@@ -44,7 +44,7 @@ async function resolvePortable() {
   const require = createRequire(import.meta.url);
   const packageJson = require("../package.json");
   const { version } = packageJson;
-  const zipFile = `Clash.Verge_${version}_${arch}_portable.zip`;
+  const zipFile = `Homiefroxy_${version}_${arch}_portable.zip`;
   zip.writeZip(zipFile);
   console.log("[INFO]: create portable zip successfully");
 }

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -3,7 +3,7 @@
   "$schema": "../node_modules/@tauri-apps/cli/config.schema.json",
   "bundle": {
     "active": true,
-    "longDescription": "Clash Verge Rev",
+    "longDescription": "Homiefroxy",
     "icon": [
       "icons/32x32.png",
       "icons/128x128.png",
@@ -12,11 +12,11 @@
       "icons/icon.ico"
     ],
     "resources": ["resources", "resources/locales/*"],
-    "publisher": "Clash Verge Rev",
+    "publisher": "Homiefroxy",
     "externalBin": ["sidecar/verge-mihomo", "sidecar/verge-mihomo-alpha"],
     "copyright": "GNU General Public License v3.0",
     "category": "DeveloperTool",
-    "shortDescription": "Clash Verge Rev",
+    "shortDescription": "Homiefroxy",
     "createUpdaterArtifacts": true
   },
   "build": {
@@ -25,7 +25,7 @@
     "beforeDevCommand": "pnpm run web:dev",
     "devUrl": "http://localhost:3000/"
   },
-  "productName": "Clash Verge",
+  "productName": "Homiefroxy",
   "identifier": "io.github.clash-verge-rev.clash-verge-rev",
   "plugins": {
     "updater": {

--- a/src-tauri/tauri.macos.conf.json
+++ b/src-tauri/tauri.macos.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "../node_modules/@tauri-apps/cli/config.schema.json",
   "identifier": "io.github.clash-verge-rev.clash-verge-rev",
-  "productName": "Clash Verge",
+  "productName": "Homiefroxy",
   "bundle": {
     "targets": ["app", "dmg"],
     "macOS": {

--- a/src/index.html
+++ b/src/index.html
@@ -8,7 +8,7 @@
       type="image/x-icon"
     />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-    <title>Clash Verge</title>
+    <title>Homiefroxy</title>
   </head>
   <body>
     <div id="root"></div>


### PR DESCRIPTION
## Summary
- rename app to Homiefroxy in Tauri configs
- update macOS product name
- change web page title
- adjust portable archive naming scripts

## Testing
- `pnpm format:check`

------
https://chatgpt.com/codex/tasks/task_e_684f5883209483288cafca6bb0b4acda