### PR TITLE
Fix auth router default redirect

### DIFF
--- a/src/pages/_routers.tsx
+++ b/src/pages/_routers.tsx
@@ -10,6 +10,7 @@ import HomePage from "./home";
 import UnlockPage from "./unlock";
 import LoginPage from "./login";
 import SignupPage from "./signup";
+import { Navigate } from "react-router-dom";
 import { BaseErrorBoundary } from "@/components/base";
 
 import HomeSvg from "@/assets/image/itemicon/home.svg?react";
@@ -103,6 +104,12 @@ export const routers = [
 }));
 
 export const authRouters = [
+  {
+    label: "Root",
+    path: "/",
+    icon: [<PersonRoundedIcon />, <PersonRoundedIcon />],
+    element: <Navigate to="/login" replace />,
+  },
   {
     label: "Label-Login",
     path: "/login",


### PR DESCRIPTION
## Summary
- redirect unauthenticated root path to the login page

## Testing
- `pnpm format:check`
- `pnpm web:build` *(fails: JavaScript heap out of memory)*

------
https://chatgpt.com/codex/tasks/task_e_684f5cd993288328947baf23355ce2c8