### PR TITLE
Fix blank page after build

### DIFF
--- a/vite.config.mts
+++ b/vite.config.mts
@@ -12,6 +12,7 @@ const monacoEditorPluginDefault = (monacoEditorPlugin as any).default as (
 
 export default defineConfig({
   root: "src",
+  base: "./",
   server: { port: 3000 },
   plugins: [
     svgr(),


### PR DESCRIPTION
## Summary
- ensure built assets use relative paths so the app works when opened directly

## Testing
- `pnpm run format:check`
- `NODE_OPTIONS='--max-old-space-size=8192' pnpm run web:build`


------
https://chatgpt.com/codex/tasks/task_e_684fd3c4f66c83288a95fcdfad71c174